### PR TITLE
Correct string color

### DIFF
--- a/Ayu — Nova.novaextension/Themes/Ayu - Mirage.css
+++ b/Ayu — Nova.novaextension/Themes/Ayu - Mirage.css
@@ -3,43 +3,50 @@ meta {
   -theme-accent-color: #ffcc66;
 }
 
-/*
+/**
  * Window styles
  */
+
 meta.window {
-  background-color: #1f2430;
+  background-color: #202530;
   border-color: #323a4d;
 }
+
 meta.titlebar {
   color: #cbccc6;
-  background: #1f2430;
+  background: #202530;
   border-color: #323a4d;
 }
+
 meta.titlebar.inactive {
-  background-color: #1f2430;
+  background-color: #202530;
 }
 
 meta.button {
   background: #33415e;
-  border: linear-gradient(hsb(210, 10%, 18%), hsb(210, 10%, 14%));
-  color: #707a8c;
+  border: linear-gradient(#292c2e, #202224);
+  color: #cbccc6;
 }
+
 meta.button.highlighted {
-  background: linear-gradient(hsl(218, 12%, 43%), hsl(218, 12%, 35%));
+  background: linear-gradient(#606a7b, #4f5664);
   color: #ffcc66;
 }
+
 meta.button.selected {
-  background: linear-gradient(hsl(40, 100%, 70%), hsl(40, 94%, 68%));
+  background: linear-gradient(#ffcc66, #fac761);
   shadow: none;
   color: #;
 }
+
 meta.button.highlighted.selected {
-  background: linear-gradient(hsl(40, 100%, 70%), hsl(40, 94%, 68%));
-  color: #1f2430;
+  background: linear-gradient(#ffcc66, #fac761);
+  color: #202530;
 }
+
 meta.button.disabled {
   background: #373e4c;
-  border: linear-gradient(hsb(210, 10%, 18%), hsb(210, 10%, 14%));
+  border: linear-gradient(#292c2e, #202224);
   color: #606a7a;
 }
 
@@ -49,36 +56,42 @@ meta.textfield {
 }
 
 meta.accent {
-  color: hsb(204, 78%, 97%);
+  color: #36aaf7;
 }
 
-/*
+/**
  * Document styles
  */
+
 meta.document {
-  background-color: #1f2430;
+  background-color: #202530;
   border-color: #323a4d;
 }
 
 meta.document.button {
   background: #33415e;
-  border: linear-gradient(hsb(210, 10%, 18%), hsb(210, 10%, 14%));
-  color: #707a8c;
+  border: linear-gradient(#292c2e, #202224);
+  color: #cbccc6;
 }
+
 meta.document.button.highlighted {
-  background: linear-gradient(hsl(218, 12%, 43%), hsl(218, 12%, 35%));
+  background: linear-gradient(#606a7b, #4f5664);
   color: #ffcc66;
 }
+
 meta.document.button.selected {
-  background: linear-gradient(hsl(40, 100%, 70%), hsl(40, 94%, 68%));
+  background: linear-gradient(#ffcc66, #fac761);
+  color: white;
 }
+
 meta.document.button.highlighted.selected {
-  background: linear-gradient(hsl(40, 100%, 70%), hsl(40, 94%, 68%));
-  color: #1f2430;
+  background: linear-gradient(#ffcc66, #fac761);
+  color: #202530;
 }
+
 meta.document.button.disabled {
   background: #373e4c;
-  border: linear-gradient(hsb(210, 10%, 18%), hsb(210, 10%, 14%));
+  border: linear-gradient(#292c2e, #202224);
   color: #606a7a;
 }
 
@@ -87,158 +100,197 @@ meta.document.textfield {
   border-color: #323a4c;
 }
 
-/* Text */
+/**
+ * Text
+ */
+
 meta.text {
-  color: hsb(210, 10%, 95%);
+  color: #cccac2;
 }
+
 meta.text.invisible {
-  color: hsb(210, 20%, 20%);
-}
-meta.text.selected {
+  color: #3f4756;
 }
 
-/* Cursor */
 meta.cursor {
-  background-color: hsl(222, 22%, 20%);
+  background-color: #1a202a;
 }
 
-/* Indentation Guides */
 meta.indentguide {
-  border-color: #707a8c4d;
+  border-color: #363a44;
 }
 
-/* Gutter */
 meta.gutter {
-  color: #707a8c66;
+  color: #4d545c;
 }
 
 meta.gutter.selected {
-  background-color: hsl(222, 22%, 20%);
-  color: #cbccc6;
+  color: #717780;
 }
 
-/*
+/**
  * Syntax styles
  */
 
 keyword {
   color: #ffa759;
 }
+
 comment {
-  color: #5c6773;
+  color: #718092;
   font-style: italic;
 }
+
+comment.doctag {
+  color: #ffa759;
+}
+
 processing {
-  color: #5c6773;
+  color: #718092;
 }
+
 declaration {
-  color: #5c6773;
+  color: #718092;
 }
+
 bracket {
-  color: #707a8c;
+  color: #e8c504;
 }
+
 operator {
-  color: F29E74;
+  color: #ffa759;
 }
+
 invalid {
-  background-color: hsb(355, 82%, 96%);
+  background-color: #f52c3d;
   color: #ff3333;
 }
+
 link {
   color: #ffa759;
 }
 
-/* Values */
-value.boolean {
-  color: #ffa759;
-}
-value.null {
-  color: #ffa759;
-}
+/**
+ * Values
+ */
+
+value.boolean,
+value.null,
 value.number {
-  color: #ffa759;
+  color: #d0b4ef;
 }
+
 value.entity {
   color: #73d0ff;
 }
+
 value.symbol {
-  color: #bae67e;
+  color: #d5ff80;
 }
 
-/* Identifiers */
+/**
+ * Identifiers
+ */
+
 identifier.type {
-  color: hsb(258, 40%, 87%);
+  color: #70caf8;
 }
-identifier.constant {
-}
+
 identifier.global,
 identifier.variable {
   color: #f29e74;
 }
-identifier.property,
+
+identifier.property {
+  color: #cccac2;
+}
+
 identifier.decorator,
 identifier.function,
 identifier.method {
   color: #ffd580;
 }
+
 identifier.key {
   color: #ffa759;
 }
+
 identifier.argument {
-  color: #bae67e;
+  color: #d0b4ef;
 }
 
-/* Strings */
+/**
+ * Strings
+ */
+
 string {
-  color: #bae67e;
+  color: #d5ff80;
 }
+
 string.key {
   color: #5ccfe6;
 }
+
 string-template {
-  color: #bae67e;
+  color: #d5ff80;
 }
+
 string-template.value {
   color: #cbccc6;
 }
+
 regex {
   color: #95e6cb;
 }
-regex.escaped {
-  color: #95e6cb;
+
+regex.escape,
+regex.operator {
+  color: #ffa759;
 }
+
 cdata {
   color: #73d0ff;
 }
 
-/* Markup */
+/**
+ * Markup
+ */
+
 markup.heading {
-  color: #bae67e;
+  color: #d5ff80;
   font-weight: bold;
 }
+
 markup.line {
-  color: #5c6773;
+  color: #718092;
 }
+
 markup.bold {
   color: #f28779;
   font-weight: bold;
 }
+
 markup.italic {
   color: #f28779;
   font-style: italic;
 }
+
 markup.strikethrough {
-  color: hsb(0, 60%, 100%);
+  color: #ff6666;
 }
+
 markup.list.item {
   color: #ffd580;
 }
+
 markup.code {
   background-color: #cbccc605;
 }
 
-/* Types */
-/* TODO */
+/**
+ * Types
+ */
+
 definition.class class.name,
 definition.type type.name,
 definition.package package.name,
@@ -246,93 +298,141 @@ definition.enum enum.name,
 definition.union union.name,
 definition.struct struct.name {
   font-weight: bold;
-  color: hsb(258, 40%, 87%);
+  color: #70caf8;
 }
 
-/* Members */
-/* TODO */
+/**
+ * Members
+ */
+
 definition.property property.name,
 definition.function function.name,
 definition.method method.name {
-  color: hsb(210, 10%, 100%);
+  color: #e6f2ff;
 }
 
-/* Tags */
+/**
+ * Tags
+ */
+
 tag {
   color: #73d0ff;
 }
+
 tag.framework {
-  color: hsb(258, 40%, 87%);
+  color: #a085de;
 }
+
 tag.attribute.name {
   color: #ffcc66;
 }
+
 tag.attribute.value {
-  color: #bae67e;
+  color: #d5ff80;
 }
+
 tag.attribute.value.link {
   color: #ffa759;
 }
 
-/* Styles */
+/**
+ * Styles
+ */
+
 style.at {
-  color: hsb(25, 75%, 100%);
+  color: #ff8f40;
   font-weight: bold;
 }
+
 style.selector.element {
   font-weight: bold;
   color: #5ccfe6;
 }
+
 style.selector.identifier.id {
   color: #ffcc66;
 }
+
 style.selector.identifier.class {
-  color: #bae67e;
+  color: #d5ff80;
 }
+
 style.selector.pseudoclass {
   color: #cbccc6;
   font-style: italic;
 }
+
 style.selector.pseudoelement {
   color: #73d0ff;
 }
+
 style.attribute.name {
   color: #707a8c;
   font-weight: bold;
 }
+
 style.value.number {
   color: #cbccc6;
 }
+
 style.value.color.hex {
   color: #5ccfe6;
 }
+
 style.value.keyword {
   color: #ffa759;
 }
+
 style.value.color.named {
   color: #ffa759;
 }
 
-/* Terminal */
+/**
+ * Terminal
+ */
 
 terminal.black {
   color: #000000;
 }
-terminal.red {
-  color: #ff4c41;
+
+terminal.bright-black {
+  color: #757779;
 }
-terminal.green {
-  color: #c4d264;
+
+terminal.red,
+terminal.bright-red {
+  color: #f28779;
 }
-terminal.yellow {
-  color: #eccd58;
+
+terminal.green,
+terminal.bright-green {
+  color: #87d96c;
 }
-terminal.blue {
-  color: #40b2e0;
+
+terminal.yellow,
+terminal.bright-yellow {
+  color: #f4c76c;
 }
-terminal.magenta {
-  color: #f5878a;
+
+terminal.blue,
+terminal.bright-blue {
+  color: #73d0ff;
 }
-terminal.cyan {
-  color: #a3e9d4;
+
+terminal.magenta,
+terminal.bright-magenta {
+  color: #debefd;
+}
+
+terminal.cyan,
+terminal.bright-cyan {
+  color: #95e6cb;
+}
+
+terminal.white {
+  color: #cccac2;
+}
+
+terminal.bright-white {
+  color: #cccac2;
 }

--- a/Ayu — Nova.novaextension/Themes/Ayu - Mirage.css
+++ b/Ayu — Nova.novaextension/Themes/Ayu - Mirage.css
@@ -190,7 +190,7 @@ identifier.argument {
 
 /* Strings */
 string {
-  color: #cbccc6;
+  color: #bae67e;
 }
 string.key {
   color: #5ccfe6;
@@ -199,7 +199,7 @@ string-template {
   color: #bae67e;
 }
 string-template.value {
-  color: ##cbccc6;
+  color: #cbccc6;
 }
 regex {
   color: #95e6cb;


### PR DESCRIPTION
The color code for `string` should be `#bae67e`.
Additionally, there is an extra hash symbol before the color code for `string-template.value` that needs to be removed.